### PR TITLE
Update Gems and Fix Mastodon API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'elasticsearch-model', '7.0.0.pre', require: 'elasticsearch/model'
 # Sign in with Mastodon
 gem 'omniauth'
 gem 'omniauth-mastodon'
-gem 'mastodon-api', github: 'tootsuite/mastodon-api'
+gem 'mastodon-api', github: 'tubbo/mastodon-api', branch: 'fix-http-and-tests'
 gem 'omniauth-rails_csrf_protection'
 # Custom Translations
 gem 'i18n-active_record', require: 'i18n/active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
-  remote: https://github.com/tootsuite/mastodon-api.git
-  revision: 4ce41980c54cb7c35fb14ada140bb44bb2181b0a
+  remote: https://github.com/tubbo/mastodon-api.git
+  revision: 492fb5dda9538697efafed271864d5ec86533fcb
+  branch: fix-http-and-tests
   specs:
     mastodon-api (2.0.0)
       addressable (~> 2.6)
@@ -112,7 +113,7 @@ GEM
       responders
       warden (~> 1.2.3)
     docile (1.3.1)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (5.0.2)
       railties (>= 4.2)
@@ -134,6 +135,9 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     friendly_id (5.2.4)
       activerecord (>= 4.0.0)
     globalid (0.4.1)
@@ -161,15 +165,16 @@ GEM
     hashdiff (0.3.7)
     hashie (3.6.0)
     hirb (0.7.3)
-    http (4.0.0)
+    http (4.2.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 2.0)
-      http_parser.rb (~> 0.6.0)
+      http-parser (~> 1.2.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http-form_data (2.1.1)
-    http_parser.rb (0.6.0)
+    http-parser (1.2.1)
+      ffi-compiler (>= 1.0, < 2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     i18n-active_record (0.2.2)
@@ -253,7 +258,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.7)
       pry (>= 0.10.4)
-    public_suffix (4.0.1)
+    public_suffix (4.0.2)
     puma (3.12.2)
     query_diet (0.6.2)
     rack (2.0.8)
@@ -384,7 +389,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
     unicode-display_width (1.4.0)
     vcr (4.0.0)
     warden (1.2.8)


### PR DESCRIPTION
Update gems that have new security fixes, and fork `mastodon-api` to fix
its HTTP parser issues while we wait for them to merge changes in the
PR.